### PR TITLE
WFSSRV: Implement RENAME

### DIFF
--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/IOS/WFS/WFSSRV.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <string>
 #include <vector>
@@ -184,6 +185,17 @@ IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
     break;
   }
 
+  case IOCTL_WFS_RENAME:
+  case 0x41:
+  {
+    const std::string source_path =
+        Memory::GetString(request.buffer_in + 2, Memory::Read_U16(request.buffer_in));
+    const std::string dest_path =
+        Memory::GetString(request.buffer_in + 512 + 2, Memory::Read_U16(request.buffer_in + 512));
+    return_error_code = Rename(source_path, dest_path);
+    break;
+  }
+
   case IOCTL_WFS_CREATE_OPEN:
   case IOCTL_WFS_OPEN:
   {
@@ -351,6 +363,19 @@ IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
   }
 
   return GetDefaultReply(return_error_code);
+}
+
+s32 WFSSRV::Rename(const std::string& source, const std::string& dest) const
+{
+  const bool opened = std::any_of(m_fds.begin(), m_fds.end(), [&](const auto& fd) {
+    return fd.in_use && fd.path == source;
+  });
+
+  if (opened)
+    return WFS_FILE_IS_OPENED;
+
+  File::Rename(WFS::NativePath(source), WFS::NativePath(dest));
+  return IPC_SUCCESS;
 }
 
 std::string WFSSRV::NormalizePath(const std::string& path) const

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -27,6 +27,7 @@ enum
   WFS_EBADFD = -10026,  // Invalid file descriptor.
   WFS_EEXIST = -10027,  // No such file or directory.
   WFS_ENOENT = -10028,  // No such file or directory.
+  WFS_FILE_IS_OPENED = -10032,  // Cannot perform operation on an opened file.
 };
 
 namespace Device
@@ -37,6 +38,8 @@ public:
   WFSSRV(Kernel& ios, const std::string& device_name);
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+
+  s32 Rename(const std::string& source, const std::string& dest) const;
 
 private:
   // WFS device name, e.g. msc01/msc02.
@@ -66,6 +69,7 @@ private:
     IOCTL_WFS_GET_HOMEDIR = 0x12,
     IOCTL_WFS_GETCWD = 0x13,
     IOCTL_WFS_DELETE = 0x15,
+    IOCTL_WFS_RENAME = 0x16,
     IOCTL_WFS_GET_ATTRIBUTES = 0x17,
     IOCTL_WFS_CREATE_OPEN = 0x19,
     IOCTL_WFS_OPEN = 0x1A,

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -25,7 +25,7 @@ std::string NativePath(const std::string& wfs_path);
 enum
 {
   WFS_EBADFD = -10026,  // Invalid file descriptor.
-  WFS_EEXIST = -10027,  // No such file or directory.
+  WFS_EEXIST = -10027,  // File already exists.
   WFS_ENOENT = -10028,  // No such file or directory.
   WFS_FILE_IS_OPENED = -10032,  // Cannot perform operation on an opened file.
 };


### PR DESCRIPTION
Noticed WFSI calls ioctl 0x16 for moving files, so we may as well implement it in WFSSRV too.